### PR TITLE
fix: via.placeholder.com shut down in 2024 (now connection-refused)

### DIFF
--- a/assets/Themes/NightOwl/CLAUDE.md
+++ b/assets/Themes/NightOwl/CLAUDE.md
@@ -355,12 +355,12 @@ Use this format for all color tables:
 ```markdown
 | Color                                                                 | Hex        | Usage             |
 | --------------------------------------------------------------------- | ---------- | ----------------- |
-| ![#hexcode](https://via.placeholder.com/15/hexcode/hexcode.png) Label | `#hexcode` | Usage description |
+| ![#hexcode](https://placehold.co/15/hexcode/hexcode.png) Label | `#hexcode` | Usage description |
 ```
 
 **Important**:
 
--   The placeholder URL format is: `https://via.placeholder.com/15/HEXCODE/HEXCODE.png` (no # symbol in URL)
+-   The placeholder URL format is: `https://placehold.co/15/HEXCODE/HEXCODE.png` (no # symbol in URL)
 -   Remove the `#` from hex codes in the placeholder URL
 -   Keep the `#` in the inline code backticks
 
@@ -563,8 +563,8 @@ color_10: "#EF5350" # Bright Red (Command error)
 **Output (README.md):**
 
 ```markdown
-| ![#ef5350](https://via.placeholder.com/15/ef5350/ef5350.png) Red | `#ef5350` | Terminal red (errors, strings) |
-| ![#ef5350](https://via.placeholder.com/15/ef5350/ef5350.png) Bright Red | `#ef5350` | Terminal bright red (errors) |
+| ![#ef5350](https://placehold.co/15/ef5350/ef5350.png) Red | `#ef5350` | Terminal red (errors, strings) |
+| ![#ef5350](https://placehold.co/15/ef5350/ef5350.png) Bright Red | `#ef5350` | Terminal bright red (errors) |
 ```
 
 ### Example 2: Syntax Colors
@@ -597,7 +597,7 @@ color_10: "#EF5350" # Bright Red (Command error)
 **Output (README.md):**
 
 ```markdown
-| ![#c792ea](https://via.placeholder.com/15/c792ea/c792ea.png) Keyword | `#c792ea` | Keywords, operators, storage types |
+| ![#c792ea](https://placehold.co/15/c792ea/c792ea.png) Keyword | `#c792ea` | Keywords, operators, storage types |
 ```
 
 ### Example 3: UI Colors
@@ -629,7 +629,7 @@ color_10: "#EF5350" # Bright Red (Command error)
 **Output (README.md):**
 
 ```markdown
-| ![#1d3b53](https://via.placeholder.com/15/1d3b53/1d3b53.png) Selection | `#1d3b53` | Text selection |
+| ![#1d3b53](https://placehold.co/15/1d3b53/1d3b53.png) Selection | `#1d3b53` | Text selection |
 ```
 
 ## Backward Compatibility Notes


### PR DESCRIPTION
`assets/Themes/NightOwl/CLAUDE.md` references `via.placeholder.com/*`. The service was shut down in 2024 and the DNS record no longer resolves.

---

#### Why this is needed

`via.placeholder.com` was shut down in 2024 and its DNS record no longer resolves — every request now hangs or returns a connection error. Any example that references it renders a broken-image icon (and any code that depends on a 200 from it silently breaks).

Verify in any shell:

```
curl -sI --max-time 3 https://via.placeholder.com/300x200 || echo "connection refused / DNS gone"
```

#### What this PR changes

Fixes the color-swatch placeholder URL format used throughout the NightOwl theme's CLAUDE.md. The original used `via.placeholder.com/15/<HEX>/<HEX>.png` to render inline color chips in Markdown tables. `placehold.co` supports the *identical* `/<size>/<bg>/<fg>.png` pattern, so every color chip (and the documented rule teaching the pattern) can be preserved 1:1.

#### Replacement details

Single replace-all across the file — every `https://via.placeholder.com/` substring becomes `https://placehold.co/`, preserving all sizes, colors, and label text. The CLAUDE.md rule at line ~363 that teaches agents *to use* the via.placeholder format is also updated, so any Claude Code session in this repo will now emit the working URL in future PRs.

#### Background

I'm tracking dead image-placeholder endpoints (`source.unsplash.com/*`, `via.placeholder.com/*`, `placekitten.com/*`) across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg is **not** a dependency of this PR — the diff uses the dependency-free canonical replacement (`placehold.co`, which accepts the same path shape as `via.placeholder.com`). If you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights dead-placeholder patterns in any landing page — useful for verifying the fix lands and for finding other places dead URLs slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.
